### PR TITLE
mouse event support

### DIFF
--- a/example/OpenGLWindow/MacOpenGLWindow.mm
+++ b/example/OpenGLWindow/MacOpenGLWindow.mm
@@ -874,7 +874,7 @@ void MacOpenGLWindow::startRendering()
 
         if (([event type]== NSRightMouseDown) || ([ event type]==NSLeftMouseDown)||([event type]==NSOtherMouseDown))
         {
-           // printf("right mouse!");
+           printf("right mouse!");
           //  float mouseX,mouseY;
             
             NSPoint eventLocation = [event locationInWindow];
@@ -904,7 +904,7 @@ void MacOpenGLWindow::startRendering()
                 
                 }
             };
-           // printf("mouse coord = %f, %f\n",mouseX,mouseY);
+           printf("mouse coord = %f, %f\n",m_mouseX,m_mouseY);
             if (m_mouseButtonCallback)
 			{
 				//handledEvent = true;
@@ -915,7 +915,7 @@ void MacOpenGLWindow::startRendering()
 		
         if (([event type]== NSRightMouseUp) || ([ event type]==NSLeftMouseUp)||([event type]==NSOtherMouseUp))
         {
-			// printf("right mouse!");
+			printf("right mouse!");
 			//  float mouseX,mouseY;
             
             NSPoint eventLocation = [event locationInWindow];

--- a/example/OpenGLWindow/MacOpenGLWindow.mm
+++ b/example/OpenGLWindow/MacOpenGLWindow.mm
@@ -874,7 +874,7 @@ void MacOpenGLWindow::startRendering()
 
         if (([event type]== NSRightMouseDown) || ([ event type]==NSLeftMouseDown)||([event type]==NSOtherMouseDown))
         {
-           printf("right mouse!");
+           // printf("right mouse!");
           //  float mouseX,mouseY;
             
             NSPoint eventLocation = [event locationInWindow];
@@ -904,7 +904,7 @@ void MacOpenGLWindow::startRendering()
                 
                 }
             };
-           printf("mouse coord = %f, %f\n",m_mouseX,m_mouseY);
+           // printf("mouse coord = %f, %f\n",mouseX,mouseY);
             if (m_mouseButtonCallback)
 			{
 				//handledEvent = true;
@@ -915,7 +915,7 @@ void MacOpenGLWindow::startRendering()
 		
         if (([event type]== NSRightMouseUp) || ([ event type]==NSLeftMouseUp)||([event type]==NSOtherMouseUp))
         {
-			printf("right mouse!");
+			// printf("right mouse!");
 			//  float mouseX,mouseY;
             
             NSPoint eventLocation = [event locationInWindow];

--- a/example/input.js
+++ b/example/input.js
@@ -921,6 +921,7 @@ function drawScissor(vg, x, y, t)
 var VG = undefined;
 var gImages = [];
 var t = 0.0;
+var click_toggle = false;
 
 function onInit() {
   try {
@@ -945,6 +946,13 @@ function onQuit() {
   }
 }
 
+var STATE_UP = 0;
+var STATE_DOWN = 1;
+function onClick(btn, state, x, y) {
+  if (state == STATE_UP)
+    click_toggle = !click_toggle;
+}
+
 function onDraw() {
 
   try {
@@ -958,20 +966,22 @@ function onDraw() {
     t = t + 0.02;
     var x, y, popy;
 
-    drawEyes(vg, width - 250, 50, 150, 100, 0, 0, t);
-    drawGraph(vg, 0, height/2, width, height/2, t);
-    drawColorwheel(vg, width - 300, height - 300, 250, 250, t);
+    if (!click_toggle) {
+      drawEyes(vg, width - 250, 50, 150, 100, 0, 0, t);
+      drawGraph(vg, 0, height/2, width, height/2, t);
+      drawColorwheel(vg, width - 300, height - 300, 250, 250, t);
 
-    // Line joints
-    drawLines(vg, 120, height-50, 600, 50, t);
+      // Line joints
+      drawLines(vg, 120, height-50, 600, 50, t);
 
-    // Line caps
-    drawWidths(vg, 10, 50, 30);
+      // Line caps
+      drawWidths(vg, 10, 50, 30);
 
-    // Line caps
-    drawCaps(vg, 10, 300, 30);
+      // Line caps
+      drawCaps(vg, 10, 300, 30);
 
-    drawScissor(vg, 50, height-80, t);
+      drawScissor(vg, 50, height-80, t);
+    }
 
     vg.save();
 

--- a/example/main.cc
+++ b/example/main.cc
@@ -408,6 +408,14 @@ void fatal_function(duk_context *ctx, duk_errcode_t code, const char *msg)
   exit(-1);
 }
 
+void checkErrors(const char *desc) {
+  GLenum e = glGetError();
+  if (e != GL_NO_ERROR) {
+    fprintf(stderr, "OpenGL error in \"%s\": %d (%d)\n", desc, e, e);
+    exit(20);
+  }
+}
+
 duk_ret_t beginPath(duk_context *ctx)
 {
   (void)ctx;
@@ -955,8 +963,12 @@ void keyboardCallback(int keycode, int state) {
   }
 }
 
-void mouseCallback(int button, int state, float x, float y) {
-  printf("hello mouse: button: %d, state: %d, x: %.2f, y: %.2f", button, state, x, y);
+void mouseButtonCallback(int button, int state, float x, float y) {
+  printf("hello mouse: button: %d, state: %d, x: %.2f, y: %.2f\n", button, state, x, y);
+}
+
+void mouseMoveCallback(float x, float y) {
+  printf("mouse move, x: %.2f, y: %.2f\n", x, y);
 }
 
 std::string ReadJSFile(const char* filename)
@@ -1035,8 +1047,11 @@ int main(int argc, char** argv)
   }
 #endif
 
+  window->setMouseButtonCallback(mouseButtonCallback);
+  window->setMouseMoveCallback(mouseMoveCallback);
+  checkErrors("mouse");
   window->setKeyboardCallback(keyboardCallback);
-  window->setMouseButtonCallback(mouseCallback);
+  checkErrors("keyboard");
 
   vg = nvgCreateGL2(NVG_ANTIALIAS | NVG_STENCIL_STROKES | NVG_DEBUG);
 

--- a/example/main.cc
+++ b/example/main.cc
@@ -42,7 +42,13 @@ extern "C" {
 #		include <ctime>
 #	endif
 #endif
-	
+
+bool mouse_btn = false;
+int mouse_btn_button = 0;
+int mouse_btn_state = 0;
+float mouse_btn_x = 0.0;
+float mouse_btn_y = 0.0;
+
 class timer{
 	public:
 #ifdef _WIN32
@@ -965,6 +971,12 @@ void keyboardCallback(int keycode, int state) {
 
 void mouseButtonCallback(int button, int state, float x, float y) {
   printf("hello mouse: button: %d, state: %d, x: %.2f, y: %.2f\n", button, state, x, y);
+  
+  mouse_btn = true;
+  mouse_btn_button = button;
+  mouse_btn_state = state;
+  mouse_btn_x = x;
+  mouse_btn_y = y;
 }
 
 void mouseMoveCallback(float x, float y) {
@@ -1173,6 +1185,19 @@ int main(int argc, char** argv)
     }
     duk_pop(ctx);  /* pop result/error */
 
+    if (mouse_btn) {
+      duk_push_global_object(ctx);
+      duk_get_prop_string(ctx, -1 /*index*/, "onClick");
+      duk_push_number(ctx, mouse_btn_button);
+      duk_push_number(ctx, mouse_btn_state);
+      duk_push_number(ctx, mouse_btn_x);
+      duk_push_number(ctx, mouse_btn_y);
+      if (duk_pcall(ctx, 4 /*nargs*/) != 0) {
+          printf("Error: %s\n", duk_safe_to_string(ctx, -1));
+      }
+      duk_pop(ctx);  /* pop result/error */
+      mouse_btn = false;
+    }
 
     renderGraph(vg, 5,5, &fps);
 

--- a/example/main.cc
+++ b/example/main.cc
@@ -955,6 +955,10 @@ void keyboardCallback(int keycode, int state) {
   }
 }
 
+void mouseCallback(int button, int state, float x, float y) {
+  printf("hello mouse: button: %d, state: %d, x: %.2f, y: %.2f", button, state, x, y);
+}
+
 std::string ReadJSFile(const char* filename)
 {
   std::ifstream f(filename, std::ifstream::binary);
@@ -1032,6 +1036,7 @@ int main(int argc, char** argv)
 #endif
 
   window->setKeyboardCallback(keyboardCallback);
+  window->setMouseButtonCallback(mouseCallback);
 
   vg = nvgCreateGL2(NVG_ANTIALIAS | NVG_STENCIL_STROKES | NVG_DEBUG);
 


### PR DESCRIPTION
@syoyo: Thanks for open-sourcing your work on this! I've been wanting to do the same thing for some time now.

I'm opening this pull request for discussion purposes, it's not anywhere near ready for merging.

I tried to start adding mouse events, but was surprised to find that my `mouseCallback` was only called after a keyboard event. At least the console output makes it look that way. I uncommented 2 `printf()`s in `MacOpenGLWindow.mm` and they seem to print immediately, but my `printf()` in `main.cc` only seems to print to the console after a keyboard event. I figured it may have something to do with the need to poll for and process events or maybe something about the stdout being paused or something.

I tried to find some documentation on bt3Gui, but couldn't find any and was tempted to try adding mouse events on the older GLFW version (before b79d0f4810) since GLFW is well-documented. Do you know if bt3Gui has any documentation?
